### PR TITLE
Implement transactional unit of work pipeline

### DIFF
--- a/Rs.Api/Registrars/MediatrRegistrar.cs
+++ b/Rs.Api/Registrars/MediatrRegistrar.cs
@@ -9,6 +9,7 @@ public class MediatrRegistrar: IWebApplicationBuilderRegistrar
             cfg.RegisterServicesFromAssembly(typeof(BaseModel).Assembly);
             cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(LoggingPipelineBehavior<,>));
             cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
+            cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(UnitOfWorkBehavior<,>));
         });
     }
 }

--- a/Rs.Application/Abstractions/Behaviors/UnitOfWorkBehavior.cs
+++ b/Rs.Application/Abstractions/Behaviors/UnitOfWorkBehavior.cs
@@ -1,0 +1,51 @@
+namespace Rs.Application.Abstractions.Behaviors;
+
+public sealed class UnitOfWorkBehavior<TRequest, TResponse>
+    : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : ICommandBase
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<UnitOfWorkBehavior<TRequest, TResponse>> _logger;
+
+    public UnitOfWorkBehavior(
+        IUnitOfWork unitOfWork,
+        ILogger<UnitOfWorkBehavior<TRequest, TResponse>> logger)
+    {
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        await _unitOfWork.BeginTransactionAsync(cancellationToken);
+
+        try
+        {
+            var response = await next();
+
+            if (response is Result result && result.IsFailure)
+            {
+                await _unitOfWork.RollbackTransactionAsync(cancellationToken);
+                return response;
+            }
+
+            await _unitOfWork.CommitTransactionAsync(cancellationToken);
+
+            return response;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(
+                exception,
+                "Unhandled exception for request {RequestName}. Rolling back transaction.",
+                typeof(TRequest).Name);
+
+            await _unitOfWork.RollbackTransactionAsync(cancellationToken);
+            throw;
+        }
+    }
+}
+

--- a/Rs.Domain/Common/Interfaces/IDataContext.cs
+++ b/Rs.Domain/Common/Interfaces/IDataContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Rs.Domain.Aggregates.PetShop;
 
 namespace Rs.Domain.Common.Interfaces;
@@ -20,7 +21,8 @@ public interface IDataContext
     DbSet<Wishlist> Wishlists { get; }
     DbSet<DiscountCoupon> DiscountCoupons { get; }
     DbSet<InventoryTransaction> InventoryTransactions { get; }
+    DatabaseFacade Database { get; }
     int SaveChanges();
 
-    Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/Rs.Domain/Common/Interfaces/IUnitOfWork.cs
+++ b/Rs.Domain/Common/Interfaces/IUnitOfWork.cs
@@ -2,7 +2,13 @@
 
 public interface IUnitOfWork
 {
-    void SaveChanges();
-    
+    int SaveChanges();
+
     Task SaveChangesAsync(CancellationToken cancellationToken = default);
+
+    Task BeginTransactionAsync(CancellationToken cancellationToken = default);
+
+    Task CommitTransactionAsync(CancellationToken cancellationToken = default);
+
+    Task RollbackTransactionAsync(CancellationToken cancellationToken = default);
 }

--- a/Rs.Persistence/UnitOfWork.cs
+++ b/Rs.Persistence/UnitOfWork.cs
@@ -1,17 +1,98 @@
-﻿using Rs.Domain.Common.Interfaces;
-using Rs.Persistence.DbPersistence;
+using Microsoft.EntityFrameworkCore.Storage;
+using Rs.Domain.Common.Interfaces;
 
 namespace Rs.Persistence;
 
-public sealed class UnitOfWork(DataContext context) : IUnitOfWork
+public sealed class UnitOfWork : IUnitOfWork, IAsyncDisposable
 {
-    public void SaveChanges()
+    private readonly IDataContext _context;
+    private IDbContextTransaction? _currentTransaction;
+
+    public UnitOfWork(IDataContext context)
     {
-        context.SaveChanges();
+        _context = context;
+    }
+
+    public int SaveChanges()
+    {
+        return _context.SaveChanges();
     }
 
     public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
     {
-        await context.SaveChangesAsync(cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task BeginTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        if (_currentTransaction is not null)
+        {
+            return;
+        }
+
+        _currentTransaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+    }
+
+    public async Task CommitTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        if (_currentTransaction is null)
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+            return;
+        }
+
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+            await _currentTransaction.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            await RollbackTransactionAsync(cancellationToken);
+            throw;
+        }
+        finally
+        {
+            await DisposeCurrentTransactionAsync();
+        }
+    }
+
+    public async Task RollbackTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        if (_currentTransaction is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _currentTransaction.RollbackAsync(cancellationToken);
+        }
+        finally
+        {
+            await DisposeCurrentTransactionAsync();
+        }
+    }
+
+    private async Task DisposeCurrentTransactionAsync()
+    {
+        if (_currentTransaction is null)
+        {
+            return;
+        }
+
+        await _currentTransaction.DisposeAsync();
+        _currentTransaction = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_currentTransaction is null)
+        {
+            return;
+        }
+
+        await _currentTransaction.DisposeAsync();
+        _currentTransaction = null;
     }
 }


### PR DESCRIPTION
## Summary
- extend the unit of work contract with transaction management capabilities and expose the EF Core database facade through IDataContext
- implement a transaction-aware UnitOfWork that coordinates save, commit, and rollback operations
- add a MediatR pipeline behavior so commands run inside a scoped transaction and register it in the API layer

## Testing
- dotnet build Rs.Api.sln *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb97b49048332b2504f4f3aca08a8