### PR TITLE
Add Docker setup with SQL Server compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+**/bin/
+**/obj/
+**/TestResults/
+**/node_modules/
+.git
+.gitignore
+.vs
+.vscode
+*.user
+*.suo
+*.swp
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY ["Rs.Api/Rs.Api.csproj", "Rs.Api/"]
+COPY ["Rs.Application/Rs.Application.csproj", "Rs.Application/"]
+COPY ["Rs.Domain/Rs.Domain.csproj", "Rs.Domain/"]
+COPY ["Rs.Infrastructure/Rs.Infrastructure.csproj", "Rs.Infrastructure/"]
+COPY ["Rs.Persistence/Rs.Persistence.csproj", "Rs.Persistence/"]
+COPY ["Rs.Utility/Rs.Utility.csproj", "Rs.Utility/"]
+
+RUN dotnet restore "Rs.Api/Rs.Api.csproj"
+
+COPY . .
+WORKDIR /src/Rs.Api
+RUN dotnet publish "Rs.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+
+ENV ASPNETCORE_URLS=http://+:8080
+
+COPY --from=build /app/publish .
+
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "Rs.Api.dll"]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ Execute the unit test suite:
 dotnet test
 ```
 
+## Running with Docker
+
+The repository includes a multi-stage `Dockerfile` for the API and a `docker-compose.yml` that provisions both the application and a SQL Server instance. To start the stack:
+
+```bash
+docker compose up --build
+```
+
+The API is exposed on [http://localhost:8080](http://localhost:8080) and connects to the SQL Server container using the connection string provided via environment variables (`ConnectionStrings__Default`). Database files are persisted in the named Docker volume `mssql-data`.
+
+To stop and remove the containers while preserving the database volume, run:
+
+```bash
+docker compose down
+```
+
 ## Notes
 
 - Connection strings are configured in `Rs.Api/appsettings*.json`. The default points to the local SQL Server LocalDB instance (`(localdb)\MSSQLLocalDB`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  api:
+    build: .
+    image: ota-api:latest
+    ports:
+      - "8080:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__Default: Server=db;Database=RsDb;User Id=sa;Password=YourStrong@Passw0rd123;TrustServerCertificate=True;Encrypt=False;MultipleActiveResultSets=True
+    depends_on:
+      - db
+  db:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    ports:
+      - "1433:1433"
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: YourStrong@Passw0rd123
+      MSSQL_PID: Developer
+    volumes:
+      - mssql-data:/var/opt/mssql
+
+volumes:
+  mssql-data:


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the Rs.Api project
- introduce a docker-compose stack wiring the API to a SQL Server container
- document how to start and stop the Docker-based environment and add a dockerignore file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf0dae1bdc83329f60ba28ee595653